### PR TITLE
chore: untrack stray node_modules, ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Environment variables
 .env
 
+# Node
+node_modules/
+
 # VsCode Stuff
 .VSCodeCounter
 build/

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "firebound",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Removes accidentally committed `node_modules/.package-lock.json` at repo root and ignores `node_modules/`.

Part of repo cleanup while resuming production. Dependency security fixes tracked separately (Dependabot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to better manage build artifacts and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->