### PR TITLE
fix(docs): pin patched transitive deps via overrides

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -46,6 +46,16 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "~5.6.2"
   },
+  "overrides": {
+    "ajv": "8.18.0",
+    "brace-expansion": "1.1.13",
+    "http-proxy-middleware": "3.0.6",
+    "joi": "17.13.4",
+    "js-yaml": "4.2.0",
+    "picomatch": "2.3.2",
+    "serialize-javascript": "7.0.5",
+    "uuid": "11.1.1"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
Adds npm `overrides` in `apps/docs` to force patched versions of transitive deps still flagged by Dependabot after the Docusaurus 3.10 bump (#269).

**Note:** lockfile not regenerated in this environment (frozen registry). It reconciles on the next `npm install` (CI/live). Verify the docs build after merge; revert if it breaks (these are build-time-only deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)