### PR TITLE
fix(docs): drop conflicting js-yaml override

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -51,7 +51,6 @@
     "brace-expansion": "1.1.13",
     "http-proxy-middleware": "3.0.6",
     "joi": "17.13.4",
-    "js-yaml": "4.2.0",
     "picomatch": "2.3.2",
     "serialize-javascript": "7.0.5",
     "uuid": "11.1.1"


### PR DESCRIPTION
npm EOVERRIDE: js-yaml is a direct dep (^4.2.0, already patched). Remove it from overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a configuration override setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->