### PR TITLE
fix(docs): drop future.faster (v4-flag cascade)

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -25,8 +25,6 @@ const config: Config = {
     onBrokenMarkdownLinks: 'warn',
     onBrokenAnchors: 'warn',
 
-    future: { faster: true },
-
     i18n: {
         defaultLocale: 'pt',
         locales: ['pt'],


### PR DESCRIPTION
faster:true requires v4 flags in Docusaurus 3.10; it's a perf opt-in. Remove for a stable build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)